### PR TITLE
Fix unit tests

### DIFF
--- a/gpu_chemistry/src/gpuChemistryModels/gpuChemistryModel/gpuChemistryModel.C
+++ b/gpu_chemistry/src/gpuChemistryModels/gpuChemistryModel/gpuChemistryModel.C
@@ -64,7 +64,7 @@ FoamGpu::GpuKernelEvaluator gpuChemistryModel<cpuThermoType>::makeEvaluator(
     auto gpu_thermos =
         FoamGpu::makeGpuThermos(mixture.specieThermos(), physicalProperties);
     auto gpu_reactions = FoamGpu::makeGpuReactions(
-        mixture.specieNames(), chemistryProperties, gpu_thermos, reactions);
+        mixture.species(), chemistryProperties, gpu_thermos, reactions);
 
     return FoamGpu::GpuKernelEvaluator(
         nCells,
@@ -82,7 +82,7 @@ gpuChemistryModel<cpuThermoType>::gpuChemistryModel(const fluidMulticomponentThe
     , mixture_(dynamicCast<const multicomponentMixture<cpuThermoType>>(
           this->thermo()))
     , specieThermos_(mixture_.specieThermos())
-    , reactions_(mixture_.specieNames(), specieThermos_, this->mesh(), *this)
+    , reactions_(mixture_.species(), specieThermos_, this->mesh(), *this)
     , RR_(this->thermo().Y().size())
     , evaluator_(makeEvaluator(
           nCells(),

--- a/gpu_chemistry/unittest/OpenFOAMReferenceKernels/openfoam_reference_kernels.C
+++ b/gpu_chemistry/unittest/OpenFOAMReferenceKernels/openfoam_reference_kernels.C
@@ -16,7 +16,7 @@ TestData::constantResults constants() {
     ret.RR     = Foam::constant::thermodynamic::RR;
     ret.Pstd   = Foam::constant::thermodynamic::Pstd;
     ret.Tstd   = Foam::constant::thermodynamic::Tstd;
-    ret.NA     = Foam::constant::physicoChemical::NA.value();
+    ret.NNA    = Foam::constant::physicoChemical::NNA.value();
     ret.k      = Foam::constant::physicoChemical::k.value();
     ret.vGreat = Foam::vGreat;
     ret.vSmall = Foam::vSmall;

--- a/gpu_chemistry/unittest/cpuTestKernels/cpu_test_kernels.C
+++ b/gpu_chemistry/unittest/cpuTestKernels/cpu_test_kernels.C
@@ -32,7 +32,7 @@ TestData::constantResults constants(){
     ret.RR = eval([] DEVICE (){return gpuRR;});
     ret.Pstd = eval([] DEVICE (){return gpuPstd;});
     ret.Tstd = eval([] DEVICE (){return gpuTstd;});
-    ret.NA = eval([] DEVICE (){return gpuNA;});
+    ret.NNA = eval([] DEVICE (){return gpuNNA;});
     ret.k = eval([] DEVICE (){return gpuk;});
     ret.vGreat = eval([] DEVICE (){return gpuVGreat;});
     ret.vSmall = eval([] DEVICE (){return gpuVSmall;});

--- a/gpu_chemistry/unittest/gpuTestKernels/gpu_test_kernels.cu
+++ b/gpu_chemistry/unittest/gpuTestKernels/gpu_test_kernels.cu
@@ -90,7 +90,7 @@ TestData::constantResults constants(){
     ret.RR = eval([] DEVICE (){return gpuRR;});
     ret.Pstd = eval([] DEVICE (){return gpuPstd;});
     ret.Tstd = eval([] DEVICE (){return gpuTstd;});
-    ret.NA = eval([] DEVICE (){return gpuNA;});
+    ret.NNA = eval([] DEVICE (){return gpuNNA;});
     ret.k = eval([] DEVICE (){return gpuk;});
     ret.vGreat = eval([] DEVICE (){return gpuVGreat;});
     ret.vSmall = eval([] DEVICE (){return gpuVSmall;});

--- a/gpu_chemistry/unittest/testHelpers/results.H
+++ b/gpu_chemistry/unittest/testHelpers/results.H
@@ -10,7 +10,7 @@ struct constantResults{
     gScalar RR;
     gScalar Pstd;
     gScalar Tstd;
-    gScalar NA;
+    gScalar NNA;
     gScalar k;
     gScalar vGreat;
     gScalar vSmall;

--- a/gpu_chemistry/unittest/tests/Test-gpuChemistry.C
+++ b/gpu_chemistry/unittest/tests/Test-gpuChemistry.C
@@ -30,7 +30,7 @@ TEST_CASE("Test gpuConstants (on CPU)", "[CPU]")
         CHECK(test_result.RR == reference.RR);
         CHECK(test_result.Pstd == reference.Pstd);
         CHECK(test_result.Tstd == reference.Tstd);
-        CHECK(test_result.NA == reference.NA);
+        CHECK(test_result.NNA == reference.NNA);
         CHECK(test_result.k == reference.k);
 
     }
@@ -55,7 +55,7 @@ TEST_CASE("Test gpuConstants (on GPU)", "[GPU]")
         CHECK(test_result.RR == reference.RR);
         CHECK(test_result.Pstd == reference.Pstd);
         CHECK(test_result.Tstd == reference.Tstd);
-        CHECK(test_result.NA == reference.NA);
+        CHECK(test_result.NNA == reference.NNA);
         CHECK(test_result.k == reference.k);
 
     }

--- a/gpu_utils/common/gpu_constants.H
+++ b/gpu_utils/common/gpu_constants.H
@@ -10,12 +10,12 @@ using gScalar = double;
 // Check OpenFOAM/OpenFOAM-gpu/etc/controlDict SI
 
 // Avagadro number
-#define gpuNA double(6.02214e+26)
+#define gpuNNA double(6.02214e+26)
 
 // Boltzman constant
 #define gpuk double(1.38065e-23)
 
-#define gpuRR double(gpuNA * gpuk)
+#define gpuRR double(gpuNNA * gpuk)
 
 // Standard pressure
 #define gpuPstd double(1e5)

--- a/tutorials/counterFlowFlame2D_GRI/constant/reactionProperties
+++ b/tutorials/counterFlowFlame2D_GRI/constant/reactionProperties
@@ -10,10 +10,10 @@ FoamFile
     format      ascii;
     class       dictionary;
     location    "constant";
-    object      combustionProperties;
+    object      reactionProperties;
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-combustionModel  laminar;
+reactionModel  laminar;
 
 // ************************************************************************* //

--- a/tutorials/scalingTest/bases/gri-base/constant/reactionProperties
+++ b/tutorials/scalingTest/bases/gri-base/constant/reactionProperties
@@ -7,15 +7,13 @@
 \*---------------------------------------------------------------------------*/
 FoamFile
 {
-    version     2.0;
     format      ascii;
     class       dictionary;
     location    "constant";
-    object      combustionProperties;
+    object      reactionProperties;
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-combustionModel  laminar;
-
+reactionModel  laminar;
 
 // ************************************************************************* //

--- a/tutorials/scalingTest/bases/h2-base/constant/reactionProperties
+++ b/tutorials/scalingTest/bases/h2-base/constant/reactionProperties
@@ -7,15 +7,13 @@
 \*---------------------------------------------------------------------------*/
 FoamFile
 {
-    version     2.0;
     format      ascii;
     class       dictionary;
     location    "constant";
-    object      combustionProperties;
+    object      reactionProperties;
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-combustionModel  laminar;
-
+reactionModel  laminar;
 
 // ************************************************************************* //

--- a/tutorials/scalingTest/bases/yao-base/constant/reactionProperties
+++ b/tutorials/scalingTest/bases/yao-base/constant/reactionProperties
@@ -7,15 +7,13 @@
 \*---------------------------------------------------------------------------*/
 FoamFile
 {
-    version     2.0;
     format      ascii;
     class       dictionary;
     location    "constant";
-    object      combustionProperties;
+    object      reactionProperties;
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-combustionModel  laminar;
-
+reactionModel  laminar;
 
 // ************************************************************************* //


### PR DESCRIPTION
This PR fixes the unit tests failing due to the NA->NNA change in OpenFOAM, in addition to the combustion->reaction renaming changes.