### PR TITLE
Fix shouldReallocate function

### DIFF
--- a/gpu_chemistry/src/memoryResource/memoryResource.H
+++ b/gpu_chemistry/src/memoryResource/memoryResource.H
@@ -47,7 +47,7 @@ protected:
 
         if ((nCells != this->nCells()) ||
             (nSpecie != this->nSpecie()) ||
-            (nCells + 2 != this->nEqns())) {
+            (nSpecie + 2 != this->nEqns())) {
             return true;
         }
         return false;

--- a/nvcc
+++ b/nvcc
@@ -7,7 +7,7 @@ NVCC_FLAGS = --std=c++17
 NVCC_FLAGS += --expt-extended-lambda
 NVCC_FLAGS += -O3
 NVCC_FLAGS += --use_fast_math
-NVCC_FLASG += --generate-line-info
+NVCC_FLAGS += --generate-line-info
 NVCC_FLAGS += -lineinfo
 NVCC_FLAGS += --gpu-architecture=compute_86 --gpu-code=sm_86
 


### PR DESCRIPTION
In `shouldReallocate` function of `memoryResource.H`, 
```cpp
    bool shouldReallocate(gLabel nCells, gLabel nSpecie) const {

        if ((nCells != this->nCells()) ||
            (nSpecie != this->nSpecie()) ||
            (nCells + 2 != this->nEqns())) {
            return true;
        }
        return false;
    }
```
the `nEqns` should be `nSpecie + 2` instead of `nCells + 2`.

The error results in momery reallocation every time step and lower the computation efficiency.