### PR TITLE
Add Treact changes

### DIFF
--- a/gpu_chemistry/src/gpuChemistryModels/gpuChemistryModel/gpuChemistryModel.C
+++ b/gpu_chemistry/src/gpuChemistryModels/gpuChemistryModel/gpuChemistryModel.C
@@ -65,7 +65,9 @@ FoamGpu::GpuKernelEvaluator gpuChemistryModel<cpuThermoType>::makeEvaluator(
         FoamGpu::makeGpuThermos(mixture.specieThermos(), physicalProperties);
     auto gpu_reactions = FoamGpu::makeGpuReactions(
         mixture.species(), chemistryProperties, gpu_thermos, reactions);
-
+    scalar Treact = chemistryProperties.lookupOrDefault<scalar>("Treact", 0.0);
+    
+    Info << "    Treact: " << Treact << " K, (below which chemistry is not solved)" << endl;
     return FoamGpu::GpuKernelEvaluator(
         nCells,
         nEqns,
@@ -73,7 +75,8 @@ FoamGpu::GpuKernelEvaluator gpuChemistryModel<cpuThermoType>::makeEvaluator(
         gpu_thermos,
         gpu_reactions,
         FoamGpu::read_gpuODESolverInputs(
-            chemistryProperties.subDict("odeCoeffs")));
+            chemistryProperties.subDict("odeCoeffs")),
+        Treact);
 }
 
 template<class cpuThermoType>

--- a/gpu_chemistry/src/gpuKernelEvaluator/gpuKernelEvaluator/gpuKernelEvaluator.H
+++ b/gpu_chemistry/src/gpuKernelEvaluator/gpuKernelEvaluator/gpuKernelEvaluator.H
@@ -26,7 +26,17 @@ public:
                        gLabel                          nSpecie,
                        const std::vector<gpuThermo>&   thermos,
                        const std::vector<gpuReaction>& reactions,
-                       gpuODESolverInputs              odeInputs);
+                       gpuODESolverInputs              odeInputs)
+        : GpuKernelEvaluator(nCells, nEqns, nSpecie, thermos, reactions, odeInputs, 0) {}
+    
+    
+    GpuKernelEvaluator(gLabel                          nCells,
+                       gLabel                          nEqns,
+                       gLabel                          nSpecie,
+                       const std::vector<gpuThermo>&   thermos,
+                       const std::vector<gpuReaction>& reactions,
+                       gpuODESolverInputs              odeInputs,
+                       gScalar                         Treact);
 
     GpuKernelEvaluator(const GpuKernelEvaluator& other) = delete;
 
@@ -71,6 +81,7 @@ private:
     gpuODESolver        solver_;
     gpuODESolverInputs  inputs_;
     gpuMemoryResource   memory_;
+    gScalar             Treact_;
 };
 
 } // namespace FoamGpu

--- a/gpu_chemistry/src/gpuKernelEvaluator/gpuKernelEvaluator/gpuKernelEvaluator.cu
+++ b/gpu_chemistry/src/gpuKernelEvaluator/gpuKernelEvaluator/gpuKernelEvaluator.cu
@@ -17,7 +17,8 @@ GpuKernelEvaluator::GpuKernelEvaluator(
     gLabel                          nSpecie,
     const std::vector<gpuThermo>&   thermos,
     const std::vector<gpuReaction>& reactions,
-    gpuODESolverInputs              odeInputs)
+    gpuODESolverInputs              odeInputs,
+    gScalar                         Treact)
     : nEqns_(nEqns)
     , nSpecie_(nSpecie)
     , nReactions_(gLabel(reactions.size()))
@@ -28,7 +29,8 @@ GpuKernelEvaluator::GpuKernelEvaluator(
               thermosReactions_.reactions())
     , solver_(make_gpuODESolver(system_, odeInputs))
     , inputs_(odeInputs)
-    , memory_(nCells, nSpecie) {}
+    , memory_(nCells, nSpecie)
+    , Treact_(Treact) {}
 
 std::pair<std::vector<gScalar>, std::vector<gScalar>>
 GpuKernelEvaluator::computeYNew(
@@ -52,7 +54,7 @@ GpuKernelEvaluator::computeYNew(
     auto buffer_span = make_mdspan(buffers, extents<1>{nCells});
 
     singleCellSolver op(
-        deltaT, nSpecie_, ddeltaTChem, dYvf, buffer_span, solver_);
+        deltaT, nSpecie_, ddeltaTChem, dYvf, buffer_span, solver_, Treact_);
 
     for_each_index(op, nCells);
 

--- a/gpu_chemistry/src/gpuKernelEvaluator/gpuKernelEvaluator/singleCellSolver.H
+++ b/gpu_chemistry/src/gpuKernelEvaluator/gpuKernelEvaluator/singleCellSolver.H
@@ -14,32 +14,39 @@ struct singleCellSolver {
                      mdspan<gScalar, 1>   deltaTChem,
                      mdspan<gScalar, 2>   Yvf,
                      mdspan<gpuBuffer, 1> buffer,
-                     gpuODESolver         ode)
+                     gpuODESolver         ode,
+                     gScalar              Treact = 0.0)
         : deltaT_(deltaT)
         , nSpecie_(nSpecie)
         , deltaTChem_(deltaTChem)
         , Yvf_(Yvf)
         , buffer_(buffer)
-        , ode_(ode) {}
+        , ode_(ode)
+        , Treact_(Treact) {}
 
     CUDA_HOSTDEV void operator()(gLabel celli) const {
         auto Y = mdspan<gScalar, 1>(&Yvf_(celli, 0),
                                     extents<1>{nSpecie_ + 2});
 
-        // Initialise time progress
-        gScalar timeLeft = deltaT_;
+        if (Y[nSpecie_] > Treact_) {
+            // Initialise time progress
+            gScalar timeLeft = deltaT_;
 
-        // Calculate the chemical source terms
-        while (timeLeft > gpuSmall) {
-            gScalar dt = timeLeft;
+            // Calculate the chemical source terms
+            while (timeLeft > gpuSmall) {
+                gScalar dt = timeLeft;
 
-            ode_.solve(0, dt, Y, deltaTChem_[celli], buffer_[celli]);
+                ode_.solve(0, dt, Y, deltaTChem_[celli], buffer_[celli]);
 
-            for (int i = 0; i < nSpecie_; i++) {
-                Y[i] = fmax(0.0, Y[i]);
+                for (int i = 0; i < nSpecie_; i++) {
+                    Y[i] = fmax(0.0, Y[i]);
+                }
+
+                timeLeft -= dt;
             }
-
-            timeLeft -= dt;
+        }
+        else {
+            deltaTChem_[celli] = deltaT_; // set the chemistry time step to the flow time step
         }
     }
 
@@ -49,6 +56,7 @@ struct singleCellSolver {
     mdspan<gScalar, 2>   Yvf_;
     mdspan<gpuBuffer, 1> buffer_;
     gpuODESolver         ode_;
+    gScalar              Treact_;
 };
 
 } // namespace FoamGpu

--- a/tutorials/counterFlowFlame2D_GRI/constant/chemistryProperties
+++ b/tutorials/counterFlowFlame2D_GRI/constant/chemistryProperties
@@ -28,6 +28,8 @@ loadBalancing   on;
 
 initialChemicalTimeStep 1e-07;
 
+Treact          295; // temperature threshold below which chemistry is not solved and reaction rate is zero 
+
 odeCoeffs
 {
     solver          Rosenbrock34;


### PR DESCRIPTION
An optional temperature threshold `Treact` was added to skip the chemistry solve when the temperature of the cell is smaller than `Treact`. 

`Treact` is provided via `chemistryProperties` dictionary, read by `makeEvaluator` function and passed to the constructors of `GpuKernelEvaluator` and `singleCellSolver`. 

The data of chemical-frozen cell is still sent to GPU in this revision.
